### PR TITLE
use threads for speedup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,8 @@ os:
   - linux
 
 julia:
-  - 1.0
-  - 1.1
-  - 1.2
   - 1.3
+  - 1.4
   - nightly
 
 # # Uncomment the following lines to allow failures on nightly julia

--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "9a8dc858-87cd-50d4-8b18-f2d562f3e4f5"
 keywords = ["LSH", "locality", "sensitive", "hashing", "weighted", "minhash"]
 license = "MIT"
 desc = "Locality Sensitive Hashing in Julia"
-version = "0.1.2"
+version = "0.2.0"
 
 [deps]
 Primes = "27ebfcd6-29c5-5fa9-bf4b-fb8fc14df3ae"
@@ -11,7 +11,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-julia = "≥ 1.0.0"
+julia = "1.3,1.4"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/LSH.jl
+++ b/src/LSH.jl
@@ -3,6 +3,7 @@ module LSH
 using Primes
 using SparseArrays
 using Statistics
+using Base.Threads
 
 import Base: match, show
 
@@ -69,7 +70,7 @@ function dochash!(dochashes::Array{T,2}, termhashes::Array{T,2}, dtm::SparseMatr
     @info("generating signatures...")
     ndocs,nhashes = size(dochashes)
 
-    for h in 1:nhashes
+    Threads.@threads for h in 1:nhashes
         th = termhashes[:,h]
         for d in 1:ndocs
             tm = dtm[d,:]


### PR DESCRIPTION
Use Base.Threads to speedup signature creation.
Updated Julia compat to >= 1.3 only.
Bumped minor version.